### PR TITLE
chore(rcm oss): update link to OpenRailAssociation organization

### DIFF
--- a/data/openrail/rcm-oss.yml
+++ b/data/openrail/rcm-oss.yml
@@ -1,7 +1,7 @@
 publiccodeYmlVersion: "0.4"
 
 name: RCM OSS
-url: "https://github.com/SchweizerischeBundesbahnen/rcm-dx"
+url: "https://github.com/OpenRailAssociation/rcm-dx"
 
 developmentStatus: stable
 


### PR DESCRIPTION
Realized during a discussion this week that the link still points to the old location in the SBB GitHub organization.